### PR TITLE
Fix double title on VLAN configuration cookbook

### DIFF
--- a/support/config-cookbooks/vlan-configuration-cookbook/index.html
+++ b/support/config-cookbooks/vlan-configuration-cookbook/index.html
@@ -2,7 +2,7 @@
 layout: page
 status: publish
 published: true
-title: VLANs
+title: Isolating VM Traffic Using VLANs
 author:
   display_name: admin
   login: admin
@@ -21,7 +21,6 @@ categories:
 tags: []
 comments: []
 ---
-<h1>Topic: Isolating VM Traffic Using VLANs</h1>
 
 <p>The goal of this configuration cookbook is to isolate VM traffic using VLANs.</p>
 


### PR DESCRIPTION
Remove the redundant <h1> title and update the title of the page in the YAML frontmatter to eliminate double titles on the VLAN configuration cookbook page.
