### PR TITLE
Fix incorrect link to discuss e-mail list

### DIFF
--- a/support/config-cookbooks/index.html
+++ b/support/config-cookbooks/index.html
@@ -22,7 +22,7 @@ tags: []
 comments: []
 ---
 <p>This page includes "Configuration Cookbooks" from the community that describe how to perform common network configuration scenarios using Open vSwitch.</p>
-<p>If you have a question regarding a cookbook entry or would like to submit, enhance, or correct an entry, please email the OVS <a href="http://mail.openvswitch.org/mailman/listinfo/discuss_openvswitch.org">discuss email list</a>.</p>
+<p>If you have a question regarding a cookbook entry or would like to submit, enhance, or correct an entry, please email the OVS <a href="http://mail.openvswitch.org/mailman/listinfo/discuss">discuss email list</a>.</p>
 <p>Cookbook Entries:</p>
 <ul>
 <li><a href="{{site.url}}/support/config-cookbooks/vlan-configuration-cookbook/">VLANs</a></li>


### PR DESCRIPTION
Fix an incorrect link to openvswitch discuss e-mail list on the Configuration Cookbook index page.
