### PR TITLE
Reformat QoS rate-limiting configuration cookbook

### DIFF
--- a/support/config-cookbooks/qos-rate-limiting/index.html
+++ b/support/config-cookbooks/qos-rate-limiting/index.html
@@ -2,7 +2,7 @@
 layout: page
 status: publish
 published: true
-title: QoS Rate-Limiting
+title: Rate-Limiting VM Traffic Using QoS Policing
 author:
   display_name: admin
   login: admin
@@ -21,49 +21,80 @@ categories:
 tags: []
 comments: []
 ---
-<p style="text-align: left;"><strong>Topic: </strong></p><br />
-Rate-limiting VMs using QoS policing.
-<p><strong>Setup:</strong></p>
-<p><span style="text-decoration: underline;">One Physical Network:</span></p>
+
+<p>The goal of this configuration cookbook is to rate-limit the traffic sent by a VM to either 1 Mbps or 10 Mbps.</p>
+
+<h2>Environment</h2>
+
+<p>This configuration cookbook uses an environment configured as described in the following sections.</p>
+
+<h3>One Physical Network</h3>
+
+<p>Data Network: Ethernet network for VM data traffic. This network is used to send traffic to and from an external host used for measuring the rate at which a VM is sending. For experimentation, this physical network is optional; you can instead connect all VMs to a bridge that is not connected to a physical interface and use a VM as the measurement host.</p>
+
+<p>There may be other networks (for example, a network for management traffic), but this configuration cookbook is only concerned with the Data Network.</p>
+
+<h3>Two Physical Hosts</h3>
+
+<p>The first host, named Host1, is a hypervisor that runs Open vSwitch and has one NIC. This single NIC, eth0, is connected to the Data Network. Because it is participating in an OVS bridge, no IP address can be assigned on eth0.</p>
+
+<p>The second host, named Measurement Host, can be any host capable of measuring throughput from a VM. For this cookbook entry, we use <a href="http://www.netperf.org">Netperf</a>, a free tool for testing the rate at which one host can send to another. The Measurement Host has only a single NIC, eth0, which is connected to the Data Network. eth0 has an IP address that can reach any VM on Host1.</p>
+
+<h3>Two VMs</h3>
+
+<p>Both VMs (VM1 andVM2) run on Host1.</p>
+
+<p>Each VM has a single interface that appears as a Linux device (e.g.,  "tap0") on the physical host. (Note: for Xen/XenServer, VM interfaces appear as Linux devices with names like "vif1.0". Other Linux systems may present these interfaces as "vnet0", "vnet1", etc.)</p>
+
+<p>This diagram illustrates the environment used in this cookbook entry:</p>
+
+<p><a href="qos-policing.png"><img title="qos-policing" src="qos-policing.png" alt="qos-policing"/></a></p>
+
+<h2>Configuration Steps</h2>
+
+<p>For both VMs, we modify the Interface table to configure an ingress policing rule. There are two values to set:</p>
 <ul>
-<li>Data Network:&nbsp; Ethernet network for VM data traffic.&nbsp; This network is used to send traffic to and from an external host used for measuring the rate at which a VM is sending.&nbsp; For  experimentation, this physical network is optional.&nbsp; You can instead  connect all VMs to a bridge that is not connected to a physical  interface and use a VM as the measurement host.</li>
-</ul><br />
-<p><span style="text-decoration: underline;">Two Physical Hosts:</span></p>
-<p>"Host1" runs Open vSwitch and has one NIC:</p>
-<ul>
-<li>eth0 is connected to the Data Network.  No IP address can be assigned on eth0.</li>
-</ul><br />
-<p>&quot;Measurement Host&quot; can be any host capable of measuring throughput from a VM.&nbsp; For this cookbook entry,  we use <a href="http://www.netperf.org">netperf</a>, a free tool for testing the rate at which one host can send to another.</p>
-<ul>
-<li>eth0 is connected to the Data Network.&nbsp; eth0 has an IP address that can reach any VM on Host1.</li>
-</ul><br />
-<span style="text-decoration: underline;">Two VMs:</span>
-<p>VM1,VM2 run on Host1.</p>
-<p>Each VM has a single interface that appears as a Linux device (e.g.,   "tap0") on the physical host.  (Note: for Xen/XenServer, VM interfaces   appears as Linux devices with names like "vif1.0")</p>
-<p style="text-align: center;"><a href="qos-policing.png"><img class="aligncenter size-full wp-image-270" title="qos-policing" src="qos-policing.png" alt="" /></a></p><br />
-<strong>Goal:</strong>
-<p>Rate-limit the traffic sent by each VM to 1 Mbps.</p>
-<strong>Configuration:</strong>
-<p>For both VMs, we modify the Interface table to configure an ingress policing rule.&nbsp; There are two values to set:</p>
-<ul>
-<li>"ingress_policing_rate": the max-rate in kbps that this VM should be allowed to send.</li>
-<li>"ingress_policing_burst": a parameter to the policing algorithm to indicate the maximum amount of data (in kb) that this interface can send beyond the policing rate.</li>
-</ul><br />
-<p>To rate limit VM1 to 1 Mbps, run:</p>
-<blockquote><p>ovs-vsctl set Interface tap0 ingress_policing_rate=1000</p>
-<p>ovs-vsctl set Interface tap0 ingress_policing_burst=100</p></blockquote><br />
-<p>Similarly, to limit VM2 to 10 Mbps, run:</p>
-<blockquote><p>ovs-vsctl set Interface tap1 ingress_policing_rate=10000</p>
-<p>ovs-vsctl set Interface tap1 ingress_policing_burst=1000</p></blockquote><br />
-<strong>Trouble-Shooting:</strong>
-<p>To test, make sure netperf is installed and running on both VMs and on the measurement host.&nbsp; Netperf consists of a client "netperf" and a server "netserver".&nbsp; In this example, we run netserver on the "Measurement Host" (installing netperf usually starts netserver as a daemon, meaning this is running by default).</p>
-<p>For this example, let's assume that the Measurement Host has an IP of 10.0.0.100 and is reachable from both VMs.</p>
-<p>From VM1, run:</p>
-<blockquote><p>netperf -H 10.0.0.100</p></blockquote><br />
-<p>This will cause VM1 to send TCP traffic as quickly as it can to the Measurement Host.&nbsp; After 10 seconds, this will output a series of values.&nbsp; We are interested in the "Throughput" value, which is measured in Mbps (10^6 bits/sec).&nbsp; For VM1 this value should be near 1.&nbsp;&nbsp; Running the same command onVM2 should give a result near 10.</p>
-<p>Open vSwitch's rate-limiting uses policing, which does not queue packets.&nbsp; It drops any packets beyond the  specified rate.&nbsp; Specifying a larger burst size lets the algorithm be more forgiving, which is important for protocols like TCP that react  severely to dropped packets.&nbsp;&nbsp; Setting a burst size of less than than the MTU (e.g., 10 kb) should be  avoided.</p>
-<p>For TCP traffic, setting a burst size to be a sizeable fraction (e.g., &gt; 10 %) of the overall policy rate helps a flow come closer to achieving the full rate.&nbsp; If a burst size is set to be a  large fraction of the overall rate, the client will actually experience  an average rate slightly higher than the specific policing rate.</p>
-<p>For UDP traffic, set the burst size to be slightly greater than the MTU and make sure that your performance tool does not send packets that are larger than your MTU (otherwise these packets will be fragmented, causing poor performance).  For example, you can force netperf to send UDP traffic as 1000 byte packets by running:</p>
-<blockquote><p>netperf -H 10.0.0.100 -t UDP_STREAM <code>--</code> -m 1000</p></blockquote><br />
-<p>Open vSwitch uses the Linux "<a href="http://lartc.org/howto/lartc.qdisc.html">traffic-control</a>" capability for rate-limiting. If you are not seeing the configured rate-limit have any affect, make sure that your kernel is built with "ingress qdisc" enabled, and that the user-space utilities (e.g., /sbin/tc )</p>
-<p>If you have problems with this cookbook entry, please send them to the OVS discuss email list.</p>
+<li>"ingress_policing_rate": the maximum rate (in Kbps) that this VM should be allowed to send.</li>
+<li>"ingress_policing_burst": a parameter to the policing algorithm to indicate the maximum amount of data (in Kb) that this interface can send beyond the policing rate.</li>
+</ul>
+<p>To rate limit VM1 to 1 Mbps, use these commands:</p>
+
+<p><code>ovs-vsctl set interface tap0 ingress_policing_rate=1000<br />
+ovs-vsctl set interface tap0 ingress_policing_burst=100</code></p>
+
+<p>Similarly, to limit VM2 to 10 Mbps, enter these commands on Host1:</p>
+
+<p><code>ovs-vsctl set interface tap1 ingress_policing_rate=10000<br />
+ovs-vsctl set interface tap1 ingress_policing_burst=1000</code></p>
+
+<p>To see the current limits applied to VM1, run this command:</p>
+
+<p><code>ovs-vsctl list interface tap0</code></p>
+
+<h2>Testing</h2>
+
+<p>To test the configuration, make sure Netperf is installed and running on both VMs and on the Measurement Host. Netperf consists of a client (<code>netperf</code>) and a server (<code>netserver</code>). In this example, we run <code>netserver</code> on the Measurement Host (installing Netperf usually starts <code>netserver</code> as a daemon, meaning this is running by default).</p>
+
+<p>For this example, we assume that the Measurement Host has an IP of 10.0.0.100 and is reachable from both VMs.</p>
+
+<p>From VM1, run this command:</p>
+
+<p><code>netperf -H 10.0.0.100</code></p>
+
+<p>This will cause VM1 to send TCP traffic as quickly as it can to the Measurement Host. After 10 seconds, this will output a series of values. We are interested in the "Throughput" value, which is measured in Mbps (10^6 bits/sec). For VM1 this value should be near 1. Running the same command on VM2 should give a result near 10.</p>
+
+<h2>Troubleshooting</h2>
+
+<p>Open vSwitch uses the Linux "<a href="http://lartc.org/howto/lartc.qdisc.html">traffic-control</a>" capability for rate-limiting. If you are not seeing the configured rate-limit have any effect, make sure that your kernel is built with "ingress qdisc" enabled, and that the user-space utilities (e.g., <code>/sbin/tc</code>) are installed.</p>
+
+<h2>Additional Information</h2>
+
+<p>Open vSwitch's rate-limiting uses policing, which does not queue packets. It drops any packets beyond the specified rate. Specifying a larger burst size lets the algorithm be more forgiving, which is important for protocols like TCP that react severely to dropped packets. Setting a burst size of less than than the MTU (e.g., 10 kb) should be avoided.</p>
+
+<p>For TCP traffic, setting a burst size to be a sizeable fraction (e.g., &gt; 10%) of the overall policy rate helps a flow come closer to achieving the full rate. If a burst size is set to be a large fraction of the overall rate, the client will actually experience an average rate slightly higher than the specific policing rate.</p>
+
+<p>For UDP traffic, set the burst size to be slightly greater than the MTU and make sure that your performance tool does not send packets that are larger than your MTU (otherwise these packets will be fragmented, causing poor performance). For example, you can force netperf to send UDP traffic as 1000 byte packets by running:</p>
+
+<p><code>netperf -H 10.0.0.100 -t UDP_STREAM -- -m 1000</code></p>
+
+<p>If you have problems with this cookbook entry, please send them to the OVS <a href="http://mail.openvswitch.org/mailman/listinfo/discuss_openvswitch.org">discuss email list</a>.</p>


### PR DESCRIPTION
Reformat the QoS rate-limiting configuration cookbook to match the other configuration cookbooks.
