### PR TITLE
Added a newline escape to sflow example for copy/pastes

### DIFF
--- a/support/config-cookbooks/sflow/index.html
+++ b/support/config-cookbooks/sflow/index.html
@@ -74,7 +74,7 @@ POLLING_SECS=10</code></p>
 
 <li><p>Still on Host1, run the following command to create an sFlow configuration and attach it to bridge br0:</p>
 
-<p><code>ovs-vsctl -- --id=@sflow create sflow agent=${AGENT_IP}<br /> target=\"${COLLECTOR_IP}:${COLLECTOR_PORT}\" header=${HEADER_BYTES}<br /> sampling=${SAMPLING_N} polling=${POLLING_SECS} -- set bridge br0 sflow=@sflow</code></p>
+<p><code>ovs-vsctl -- --id=@sflow create sflow agent=${AGENT_IP} \ <br /> target=\"${COLLECTOR_IP}:${COLLECTOR_PORT}\" header=${HEADER_BYTES} \ <br /> sampling=${SAMPLING_N} polling=${POLLING_SECS} -- set bridge br0 sflow=@sflow</code></p>
 
 <p>Make note of the UUID that is returned by this command; this value is necessary to remove the sFlow configuration.</p></li>
 


### PR DESCRIPTION
Adding a backslash at the html breaks in the sflow
example to avoid any confusion for the copy and pasters
like myself :)

Before Patch:
ovs-vsctl -- --id=@sflow create sflow agent=${AGENT_IP}
target=\"${COLLECTOR_IP}:${COLLECTOR_PORT}\" header=${HEADER_BYTES}
sampling=${SAMPLING_N} polling=${POLLING_SECS} -- set bridge br0 sflow=@sflow

After Patch:
ovs-vsctl -- --id=@sflow create sflow agent=${AGENT_IP} \
target=\"${COLLECTOR_IP}:${COLLECTOR_PORT}\" header=${HEADER_BYTES} \
sampling=${SAMPLING_N} polling=${POLLING_SECS} -- set bridge br0 sflow=@sflow

Thanks!

Signed-off-by: Brent Salisbury <brent@socketplane.io>