### PR TITLE
_layouts: Include CSS inline

### DIFF
--- a/_includes/style.css
+++ b/_includes/style.css
@@ -1,0 +1,339 @@
+/* General */
+
+*:before,
+*:after {
+    box-sizing: border-box;
+}
+
+div {
+    vertical-align:top;
+}
+
+h1::after {
+    width: 100px;
+    height: 6px;
+    background-color: #4f8a49;
+    content: '';
+    margin-top: 20px;
+    margin-bottom: 20px;
+    display: block;
+}
+
+p {
+    vertical-align:baseline;
+}
+
+a {
+    text-decoration: none;
+    font-weight: 700;
+}
+
+img {
+    max-width:100%;
+    max-height:100%;
+}
+
+pre {
+    overflow: auto;
+}
+
+a:hover {
+    color:#444;
+}
+
+a:visited {
+    color:#447099;
+}
+
+a:link {
+    color:#447099;
+}
+
+body {
+    font-family: Arial,Helvetica,sans-serif;
+    font-size: 14px;
+    line-height: 1.5em;
+    margin: 0;
+}
+
+.container {
+    margin-right: auto;
+    margin-left: auto;
+    padding-left: 20px;
+    padding-right: 20px;
+}
+
+@media only screen and (min-width: 768px) {
+    .container {
+        width: 750px;
+    }
+}
+
+@media only screen and (min-width: 1200px) {
+    .container {
+        width: 1200px;
+    }
+}
+
+/* Navbar */
+
+.subnav {
+    background-color: #23241f;
+    margin: 0px;
+}
+
+.menu a {
+    color: #FFF;
+    font-size: 12px;
+}
+
+.menu div {
+    margin:0px;
+    padding: 13px 10px;
+    padding-left: 10px;
+}
+
+.menu li {
+    background-color: #23241F;
+}
+
+.menu li:hover {
+    background-color: #333;
+}
+
+.menu li>ul>li {
+    background-color: #888;
+}
+
+.menu li>ul>li:hover {
+    background-color: #999;
+}
+
+.menu {
+    width: 100%;
+    padding-left:0px;
+}
+
+.menu li {
+    list-style: none;
+    text-align: left;
+    display: inline-block;
+    white-space: nowrap;
+}
+
+.menu li>ul {
+    position: absolute;
+    display: none;
+}
+
+.menu li ul {
+    padding-left:0;
+}
+
+.menu li:hover>ul {
+    display: block;
+}
+
+.menu li>ul>li {
+    display: block;
+}
+
+.menu li>ul>li {
+    position: relative;
+    border-left: 0px solid black;
+    border-right: 0px solid black;
+    border-bottom: 0px solid black;
+}
+
+/* Displays 2+ level submenus next to (not under) the parent */
+.menu a.l2submenu {
+    display:inline-block;
+}
+
+.menu li ul li:hover > ul {
+    display:inline-block;
+}
+
+/* Footer */
+
+footer[role="contentinfo"] {
+    background: #404042;
+    overflow:auto;
+    padding:10px;
+}
+
+.footer-piece {
+    display:inline-block;
+}
+
+.footer-links {
+  list-style: none;
+}
+
+.footer-links li {
+  display: inline-block;
+}
+
+.footer-links li+li {
+  margin-left: 10px;
+}
+
+/* Grid */
+
+.section {
+    clear: both;
+    padding: 0px;
+    margin: 0px;
+}
+
+.group:before,
+.group:after {
+    content: "";
+    display: table;
+}
+
+.group:after {
+    clear: both;
+}
+
+.group {
+    zoom: 1; /* For IE 6/7 */
+}
+
+.col-1-1,
+.col-1-2,
+.col-1-3,
+.col-2-3 {
+    display: block;
+    float:left;
+    margin: 1% 0 1% 1.6%;
+}
+
+.col-1-1:first-child,
+.col-1-2:first-child,
+.col-1-3:first-child,
+.col-2-3:first-child{
+    margin-left: 0;
+}
+
+.col-1-1 {
+    width: 100%;
+}
+
+.col-1-2 {
+    width: 49.2%;
+}
+
+.col-1-3 {
+    width: 32.26%;
+}
+
+.col-2-3 {
+    width: 66.13%;
+}
+
+@media only screen and (max-width: 480px) {
+    .col-1-1,
+    .col-1-2,
+    .col-1-3,
+    .col-2-3{
+        width: 100%;
+    }
+}
+
+/* Tables */
+
+.left {
+    text-align:left;
+    float:left;
+}
+
+.center {
+    text-align:center;
+    margin:0px auto;
+}
+
+.right {
+    text-align:right;
+    float:right;
+}
+
+/* Widgets */
+
+.side-widgets {
+    margin-top: 36px;
+    display: inline-block;
+    width: 300px;
+    vertical-align: top;
+}
+
+.widget-title {
+    background-color: #f5f5f5;
+    font-weight: bold;
+    text-align: center;
+    padding-top: 3px;
+    padding-bottom: 3px;
+}
+
+.widget-body {
+    padding: 2px;
+}
+
+.widget-body ul {
+    list-style:none;
+    padding:0;
+    margin:0;
+}
+
+/* Other */
+
+.featured-button {
+    background: url('{{site.url}}/assets/featured-button.png') no-repeat scroll 0px 0px transparent;
+    cursor: pointer;
+    color: #444;
+    height: 61px;
+    width: 230px;
+    text-align: center;
+    text-shadow: 0px 1px #FFF;
+    text-transform: uppercase;
+    font-weight: bold;
+    font-size: 18px;
+    display: table-cell;
+    vertical-align: middle;
+}
+
+.featured-button:hover {
+    background-position: 0px -61px;
+}
+
+.codeclass {
+    font-family:monospace;
+}
+
+/* Linux Collaborative Projects header */
+
+.collaborative-projects .gray-diagonal {
+    background: url({{site.url}}/assets/lf/di_dark_gray.png) repeat 0 0;
+}
+
+#cp--logo {
+    display:block;
+}
+
+.cp--header {
+    background: #404042;
+    background-image: linear-gradient(to right,#404042 0%,#3b393b 69%);
+    display: block;
+    height: 30px;
+    z-index: 1;
+    padding-left: 10px;
+}
+.cp--header .container {
+    padding-top:7px;
+}
+
+.cp--footer p {
+    font-size: 0.75rem;
+    color: #ABABAB;
+    margin: 0px;
+}

--- a/_layouts/skel.html
+++ b/_layouts/skel.html
@@ -3,9 +3,11 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" type="text/css" href="{{site.url}}/assets/style.css">
   <link rel="shortcut icon" href="{{site.url}}/assets/vswitch.ico">
   <title>{{ page.title }}</title>
+  <style>
+{% include style.css %}
+  </style>
 </head>
 <body {% if page.body_class %}class="{{ page.body_class }}"{% endif %}>
 {% include header.html %}


### PR DESCRIPTION
For some reason, GitHub Pages doesn't seem to be including the assets
like it should be and is replacing them with normalize. I don't know why
this is, but it could be a while before I figure out what's happening.

In the interim, hack around the problem by just moving the CSS inline.
This involves copying 'style.css' to the the '_includes' folder so we
can "include" it inside a '<style>' tag.

Signed-off-by: Stephen Finucane <stephen@that.guru>