### PR TITLE
ovscon2021: Fix the affiliation for Sergey Madaminov

### DIFF
--- a/support/ovscon2021/index.html
+++ b/support/ovscon2021/index.html
@@ -501,7 +501,7 @@ title: Open vSwitch and OVN 2021 Fall Conference
          offload sequences that a given implementation has to consider.
      </p>
      <h3>One build system to rule them all: the return of the meson</h3>
-     <p>Speakers: Sergey Madaminov (VMWare, Inc.), William Tu (VMWare, Inc.)</p>
+     <p>Speakers: Sergey Madaminov (Stony Brook University), William Tu (VMWare, Inc.)</p>
 
      <p> As of now, OVS uses the autotools suite as its build system. Even though it
          is a powerful set of tools, it has few disadvantages. Autotools have a


### PR DESCRIPTION
This was inadvertently flagged as VMWare, but should have been
Stony Brook University.

Signed-off-by: Aaron Conole <aconole@redhat.com>