### PR TITLE
schedule: Add missing NVIDIA talk

### DIFF
--- a/support/ovscon2021/index.html
+++ b/support/ovscon2021/index.html
@@ -110,57 +110,58 @@ function update_times() {
 }
 </script>
 <label for="gmtoff">UTC offset:</label>
-<input type="text" id="gmtoff" name="gmtoff" value="-700" size="8" maxlength="5" onchange="update_times();">
+<input type="text" id="gmtoff" name="gmtoff" value="-800" size="8" maxlength="5" onchange="update_times();">
 
      <h2>Day 1:</h2>
      <table border=1>
          <tr><th>Talk</th><th>Start Time</th><th>Talk Type</th></tr>
-         <tr><td>Welcome / Introduction</td><td class="time" day="7" start="960" end="970">Dec. 7, 09:00 - 09:10</td><td>Intro</td></tr>
-         <tr><td><a id="sT9" href="#T9">Improving online and offline flow debugging with ofparse and ovs-offline</a></td><td class="time" day="7" start="970" end="995">Dec. 7, 09:10 - 09:35</td><td>Full</td></tr>
-         <tr><td><a href="#T1" id="sT1">Debugging OVS using static tracepoints</a></td><td class="time" day="7" start="995" end="1020">Dec. 7, 09:35 - 10:00</td><td>Full</td></tr>
-         <tr><td><a href="#T29" id="sT29">Debugging unit tests with OVS_PAUSE_TEST</a></td><td class="time" day="7" start="1020" end="1030">Dec. 7, 10:00 - 10:10</td><td>Lightning</td></tr>
-         <tr><td><a href="#T31" id="sT31">One build system to rule them all: the return of the meson</a></td><td class="time" day="7" start="1030" end="1055">Dec. 7, 10:10 - 10:35</td><td>Full</td></tr>
-         <tr><td>Break</td><td class="time" day="7" start="1055" end="1070">Dec. 7, 10:35 - 10:50</td><td>Break</td></tr>
-         <tr><td><a href="#T5" id="sT5">Scale OVN To The Next Level</a></td><td class="time" day="7" start="1070" end="1095">Dec. 7, 10:50 - 11:15</td><td>Full</td></tr>
-         <tr><td><a href="#T17" id="sT17">OVN Hardware offload</a></td><td class="time" day="7" start="1095" end="1120">Dec. 7, 11:15 - 11:40</td><td>Full</td></tr>
-         <tr><td><a href="#T11" id="sT11">OVN Offload the Next Generation, starring OpenShift and BlueField-2</a></td><td class="time" day="7" start="1120" end="1145">Dec. 7, 11:40 - 12:05</td><td>Full</td></tr>
-         <tr><td>Break</td><td class="time" day="7" start="1145" end="1160">Dec. 7, 12:05 - 12:20</td><td>Break</td></tr>
-         <tr><td><a href="#T7" id="sT7">Measuring Geneve Tunnel Throughput for Hardware-Accelerated DataPath with OVN!!</a></td><td class="time" day="7" start="1160" end="1185">Dec. 7, 12:20 - 12:45</td><td>Full</td></tr>
-         <tr><td><a href="#T14" id="sT14">Scaling testing a k8s cluster with OVN and kind</a></td><td class="time" day="7" start="1185" end="1195">Dec. 7, 12:45 - 12:55</td><td>Lightning</td></tr>
-         <tr><td><a href="#T8" id="sT8">OVSDB just got a new monitor (and TUI): welcome the ovsdb-mon</a></td><td class="time" day="7" start="1195" end="1205">Dec. 7, 12:55 - 13:05</td><td>Lightning</td></tr>
-         <tr><td><a href="#T21" id="sT21">Nodus - Service function chaining using OVN in Kubernetes</a></td><td class="time" day="7" start="1205" end="1215">Dec. 7, 13:05 - 13:15</td><td>Lightning</td></tr>
-         <tr><td><a href="#T13" id="sT13">Multiple distributed gateway ports with OVN.</a></td><td class="time" day="7" start="1215" end="1240">Dec. 7, 13:15 - 13:40</td><td>Full</td></tr>
-         <tr><td><a href="#T23" id="sT23">Off-path SmartNIC Port Binding with OVN</a></td><td class="time" day="7" start="1240" end="1265">Dec. 7, 13:40 - 14:05</td><td>Full</td></tr>
-         <tr><td>Break</td><td class="time" day="7" start="1265" end="1280">Dec. 7, 14:05 - 14:20</td><td>Break</td></tr>
-         <tr><td><a href="#T30" id="sT30">OVS-DPDK Full VXLAN Offload with SR-IOV</a></td><td class="time" day="7" start="1280" end="1290">Dec. 7, 14:20 - 14:30</td><td>Lightning</td></tr>
-         <tr><td><a href="#T34" id="sT34">Recirculating the Journey to Higher Performance in the OVS SW Datapath</a></td><td class="time" day="7" start="1290" end="1300">Dec. 7, 14:30 - 14:40</td><td>Lightning</td></tr>
-         <tr><td><a href="#T28" id="sT28">Specify L2 information as part of Tunnel definition</a></td><td class="time" day="7" start="1300" end="1310">Dec. 7, 14:40 - 14:50</td><td>Lightning</td></tr>
-         <tr><td><a href="#T4" id="sT4">Parallel offload processing in OvS-DPDK</a></td><td class="time" day="7" start="1310" end="1335">Dec. 7, 14:50 - 15:15</td><td>Full</td></tr>
+         <tr><td>Welcome / Introduction</td><td class="time" day="7" start="1020" end="1030">Dec. 7, 09:00 - 09:10</td><td>Intro</td></tr>
+         <tr><td><a id="sT9" href="#T9">Improving online and offline flow debugging with ofparse and ovs-offline</a></td><td class="time" day="7" start="1030" end="1055">Dec. 7, 09:10 - 09:35</td><td>Full</td></tr>
+         <tr><td><a href="#T1" id="sT1">Debugging OVS using static tracepoints</a></td><td class="time" day="7" start="1055" end="1080">Dec. 7, 09:35 - 10:00</td><td>Full</td></tr>
+         <tr><td><a href="#T29" id="sT29">Debugging unit tests with OVS_PAUSE_TEST</a></td><td class="time" day="7" start="1080" end="1090">Dec. 7, 10:00 - 10:10</td><td>Lightning</td></tr>
+         <tr><td><a href="#T31" id="sT31">One build system to rule them all: the return of the meson</a></td><td class="time" day="7" start="1090" end="1115">Dec. 7, 10:10 - 10:35</td><td>Full</td></tr>
+         <tr><td>Break</td><td class="time" day="7" start="1115" end="1130">Dec. 7, 10:35 - 10:50</td><td>Break</td></tr>
+         <tr><td><a href="#T5" id="sT5">Scale OVN To The Next Level</a></td><td class="time" day="7" start="1130" end="1155">Dec. 7, 10:50 - 11:15</td><td>Full</td></tr>
+         <tr><td><a href="#T17" id="sT17">OVN Hardware offload</a></td><td class="time" day="7" start="1155" end="1180">Dec. 7, 11:15 - 11:40</td><td>Full</td></tr>
+         <tr><td><a href="#T11" id="sT11">OVN Offload the Next Generation, starring OpenShift and BlueField-2</a></td><td class="time" day="7" start="1180" end="1205">Dec. 7, 11:40 - 12:05</td><td>Full</td></tr>
+         <tr><td>Break</td><td class="time" day="7" start="1205" end="1220">Dec. 7, 12:05 - 12:20</td><td>Break</td></tr>
+         <tr><td><a href="#T7" id="sT7">Measuring Geneve Tunnel Throughput for Hardware-Accelerated DataPath with OVN!!</a></td><td class="time" day="7" start="1220" end="1245">Dec. 7, 12:20 - 12:45</td><td>Full</td></tr>
+         <tr><td><a href="#T14" id="sT14">Scaling testing a k8s cluster with OVN and kind</a></td><td class="time" day="7" start="1245" end="1255">Dec. 7, 12:45 - 12:55</td><td>Lightning</td></tr>
+         <tr><td><a href="#T8" id="sT8">OVSDB just got a new monitor (and TUI): welcome the ovsdb-mon</a></td><td class="time" day="7" start="1255" end="1265">Dec. 7, 12:55 - 13:05</td><td>Lightning</td></tr>
+         <tr><td><a href="#T21" id="sT21">Nodus - Service function chaining using OVN in Kubernetes</a></td><td class="time" day="7" start="1265" end="1275">Dec. 7, 13:05 - 13:15</td><td>Lightning</td></tr>
+         <tr><td><a href="#T13" id="sT13">Multiple distributed gateway ports with OVN.</a></td><td class="time" day="7" start="1275" end="1285">Dec. 7, 13:15 - 13:25</td><td>Lightning</td></tr>
+         <tr><td><a href="#T35" id="sT35">DPU and OVN enable zero trust multi-tenant cloud on steroids</a></td><td class="time" day="7" start="1285" end="1295">Dec. 7, 13:25 - 13:35</td><td>Lightning</td></tr>
+         <tr><td><a href="#T23" id="sT23">Off-path SmartNIC Port Binding with OVN</a></td><td class="time" day="7" start="1295" end="1320">Dec. 7, 13:35 - 14:00</td><td>Full</td></tr>
+         <tr><td>Break</td><td class="time" day="7" start="1320" end="1335">Dec. 7, 14:00 - 14:15</td><td>Break</td></tr>
+         <tr><td><a href="#T30" id="sT30">OVS-DPDK Full VXLAN Offload with SR-IOV</a></td><td class="time" day="7" start="1335" end="1345">Dec. 7, 14:20 - 14:30</td><td>Lightning</td></tr>
+         <tr><td><a href="#T34" id="sT34">Recirculating the Journey to Higher Performance in the OVS SW Datapath</a></td><td class="time" day="7" start="1345" end="1355">Dec. 7, 14:30 - 14:40</td><td>Lightning</td></tr>
+         <tr><td><a href="#T28" id="sT28">Specify L2 information as part of Tunnel definition</a></td><td class="time" day="7" start="1355" end="1365">Dec. 7, 14:40 - 14:50</td><td>Lightning</td></tr>
+         <tr><td><a href="#T4" id="sT4">Parallel offload processing in OvS-DPDK</a></td><td class="time" day="7" start="1365" end="1390">Dec. 7, 14:50 - 15:15</td><td>Full</td></tr>
      </table>
 
      <h2>Day 2:</h2>
      <table border="1">
-         <tr><td>Welcome / Introduction</td><td class="time" day="8" start="960" end="970">Dec. 8, 09:00 - 09:10</td><td>Intro</td></tr>
-         <tr><td><a href="#T22" id="sT22">OVSDB: Performance and Scale Journey '21</a></td><td class="time" day="8" start="970" end="995">Dec. 8, 09:10 - 09:35</td><td>Full</td></tr>
-         <tr><td><a href="#T25" id="sT25">Control plane performance and scalability improvements in OVN 21.09</a></td><td class="time" day="8" start="995" end="1020">Dec. 8, 09:35 - 10:00</td><td>Full</td></tr>
-         <tr><td><a href="#T15" id="sT15">SDN Control Plane Approaches: A DDlog Retrospective</a></td><td class="time" day="8" start="1020" end="1045">Dec. 8, 10:00 - 10:25</td><td>Full</td></tr>
-         <tr><td><a href="#T26" id="sT26">The transience of the physical world</a></td><td class="time" day="8" start="1045" end="1055">Dec. 8, 10:25 - 10:35</td><td>Lightning</td></tr>
-         <tr><td>Break</td><td class="time" day="8" start="1055" end="1070">Dec. 8, 10:35 - 10:50</td><td>Break</td></tr>
-         <tr><td><a href="#T12" id="sT12">The state of DMA offload for Para-virtual I/O in OVS-DPDK.</a></td><td class="time" day="8" start="1070" end="1095">Dec. 8, 10:50 - 11:15</td><td>Full</td></tr>
-         <tr><td><a href="#T32" id="sT32">High-performance packet parsing in OVS: Using AVX512 for Miniflow Extract and Protocol Specific Hashing</a></td><td class="time" day="8" start="1095" end="1120">Dec. 8, 11:15 - 11:40</td><td>Full</td></tr>
-         <tr><td><a href="#T33" id="sT33">Aaaand Action! Using AVX512 to optimize OVS packet modifications</a></td><td class="time" day="8" start="1120" end="1165">Dec. 8, 11:40 - 12:05</td><td>Full</td></tr>
-         <tr><td>Break</td><td class="time" day="8" start="1165" end="1180">Dec. 8, 12:05 - 12:20</td><td>Break</td></tr>
-         <tr><td><a href="#T3" id="sT3">NIC acceleration of Open vSwitch</a></td><td class="time" day="8" start="1180" end="1205">Dec. 8, 12:20 - 12:45</td><td>Full</td></tr>
-         <tr><td><a href="#T19" id="sT19">OVS DPDK Community Auto validation</a></td><td class="time" day="8" start="1205" end="1215">Dec. 8, 12:45 - 12:55</td><td>Lightning</td></tr>
-         <tr><td><a href="#T20" id="sT20">Windows data-path for OVS</a></td><td class="time" day="8" start="1215" end="1225">Dec. 8, 12:55 - 13:05</td><td>Lightning</td></tr>
-         <tr><td><a href="#T16" id="sT16">OVS-DPDK on Windows</a></td><td class="time" day="8" start="1225" end="1250">Dec. 8, 13:05 - 13:30</td><td>Full</td></tr>
-         <tr><td><a href="#T18" id="sT18">A new solution to support connection tracking in OVS to get higher performance in softeware datapath in OVS.</a></td><td class="time" day="8" start="1250" end="1275">Dec. 8, 13:30 - 13:55</td><td>Full</td></tr>
-         <tr><td>Break</td><td class="time" day="8" start="1275" end="1290">Dec. 8, 13:55 - 14:10</td><td>Break</td></tr>
-         <tr><td><a href="#T27" id="sT27">Virtio Forwarder Enhancements for OvS-DPDK Full vhost Offload with SR-IOV</a></td><td class="time" day="8" start="1290" end="1300">Dec. 8, 14:10 - 14:20</td><td>Lightning</td></tr>
-         <tr><td><a href="#T24" id="sT24">Dynamic Rebalancing of Offloaded Flows for OvS-DPDK</a></td><td class="time" day="8" start="1300" end="1310">Dec. 8, 14:20 - 14:30</td><td>Lightning</td></tr>
-         <tr><td><a href="#T10" id="sT10">Multi-core Scaling: PMD auto load balance improvements.</a></td><td class="time" day="8" start="1310" end="1320">Dec. 8, 14:30 - 14:40</td><td>Lightning</td></tr>
-         <tr><td><a href="#T6" id="sT6">How virtual machines access our metadata service</a></td><td class="time" day="8" start="1320" end="1330">Dec. 8, 14:40 - 14:50</td><td>Lightning</td></tr>
-         <tr><td><a href="#T2" id="sT2">Make OVS DPDK a First-class Citizen in Openstack</a></td><td class="time" day="8" start="1330" end="1355">Dec. 8, 14:50 - 15:15</td><td>Full</td></tr>
+         <tr><td>Welcome / Introduction</td><td class="time" day="8" start="1020" end="1030">Dec. 8, 09:00 - 09:10</td><td>Intro</td></tr>
+         <tr><td><a href="#T22" id="sT22">OVSDB: Performance and Scale Journey '21</a></td><td class="time" day="8" start="1030" end="1055">Dec. 8, 09:10 - 09:35</td><td>Full</td></tr>
+         <tr><td><a href="#T25" id="sT25">Control plane performance and scalability improvements in OVN 21.09</a></td><td class="time" day="8" start="1055" end="1080">Dec. 8, 09:35 - 10:00</td><td>Full</td></tr>
+         <tr><td><a href="#T15" id="sT15">SDN Control Plane Approaches: A DDlog Retrospective</a></td><td class="time" day="8" start="1080" end="1105">Dec. 8, 10:00 - 10:25</td><td>Full</td></tr>
+         <tr><td><a href="#T26" id="sT26">The transience of the physical world</a></td><td class="time" day="8" start="1105" end="1115">Dec. 8, 10:25 - 10:35</td><td>Lightning</td></tr>
+         <tr><td>Break</td><td class="time" day="8" start="1115" end="1130">Dec. 8, 10:35 - 10:50</td><td>Break</td></tr>
+         <tr><td><a href="#T12" id="sT12">The state of DMA offload for Para-virtual I/O in OVS-DPDK.</a></td><td class="time" day="8" start="1130" end="1155">Dec. 8, 10:50 - 11:15</td><td>Full</td></tr>
+         <tr><td><a href="#T32" id="sT32">High-performance packet parsing in OVS: Using AVX512 for Miniflow Extract and Protocol Specific Hashing</a></td><td class="time" day="8" start="1155" end="1180">Dec. 8, 11:15 - 11:40</td><td>Full</td></tr>
+         <tr><td><a href="#T33" id="sT33">Aaaand Action! Using AVX512 to optimize OVS packet modifications</a></td><td class="time" day="8" start="1180" end="1205">Dec. 8, 11:40 - 12:05</td><td>Full</td></tr>
+         <tr><td>Break</td><td class="time" day="8" start="1205" end="1220">Dec. 8, 12:05 - 12:20</td><td>Break</td></tr>
+         <tr><td><a href="#T3" id="sT3">NIC acceleration of Open vSwitch</a></td><td class="time" day="8" start="1220" end="1245">Dec. 8, 12:20 - 12:45</td><td>Full</td></tr>
+         <tr><td><a href="#T19" id="sT19">OVS DPDK Community Auto validation</a></td><td class="time" day="8" start="1245" end="1255">Dec. 8, 12:45 - 12:55</td><td>Lightning</td></tr>
+         <tr><td><a href="#T20" id="sT20">Windows data-path for OVS</a></td><td class="time" day="8" start="1255" end="1265">Dec. 8, 12:55 - 13:05</td><td>Lightning</td></tr>
+         <tr><td><a href="#T16" id="sT16">OVS-DPDK on Windows</a></td><td class="time" day="8" start="1265" end="1290">Dec. 8, 13:05 - 13:30</td><td>Full</td></tr>
+         <tr><td><a href="#T18" id="sT18">A new solution to support connection tracking in OVS to get higher performance in softeware datapath in OVS.</a></td><td class="time" day="8" start="1290" end="1315">Dec. 8, 13:30 - 13:55</td><td>Full</td></tr>
+         <tr><td>Break</td><td class="time" day="8" start="1315" end="1330">Dec. 8, 13:55 - 14:10</td><td>Break</td></tr>
+         <tr><td><a href="#T27" id="sT27">Virtio Forwarder Enhancements for OvS-DPDK Full vhost Offload with SR-IOV</a></td><td class="time" day="8" start="1330" end="1340">Dec. 8, 14:10 - 14:20</td><td>Lightning</td></tr>
+         <tr><td><a href="#T24" id="sT24">Dynamic Rebalancing of Offloaded Flows for OvS-DPDK</a></td><td class="time" day="8" start="1340" end="1350">Dec. 8, 14:20 - 14:30</td><td>Lightning</td></tr>
+         <tr><td><a href="#T10" id="sT10">Multi-core Scaling: PMD auto load balance improvements.</a></td><td class="time" day="8" start="1350" end="1360">Dec. 8, 14:30 - 14:40</td><td>Lightning</td></tr>
+         <tr><td><a href="#T6" id="sT6">How virtual machines access our metadata service</a></td><td class="time" day="8" start="1360" end="1370">Dec. 8, 14:40 - 14:50</td><td>Lightning</td></tr>
+         <tr><td><a href="#T2" id="sT2">Make OVS DPDK a First-class Citizen in Openstack</a></td><td class="time" day="8" start="1370" end="1395">Dec. 8, 14:50 - 15:15</td><td>Full</td></tr>
      </table>
 
      <h2>Abstracts:</h2>
@@ -694,3 +695,10 @@ function update_times() {
          and Miniflow Extract (MFEX) for handling "inner" (or "recirculated") packets. An AVX512
          optimized implementation of DPIF and MFEX for inner packet handling will be used for
          showing performance benefits.</p>
+     <h3 id="T35"><a href="#sT35">DPU and OVN enable zero trust multi-tenant cloud on steroids</a></h3>
+     <p>Speakers: Rony Efraim (NVIDIA Corporation)</p>
+
+     <p>Mellanox started the OVS HW offload long time ago, we first show it in openVswitch conference at 2016.
+        Since then we improving HW capability’s  and functionality like GENEVE, CT, NAT, miters and DPDK support .
+        Today we offload the entire  OVN  to the DPU. Getting a 100Gb/s for full OVN-K8s pipeline with HW acceleration.
+        The OVN offload is used for virtualization and for infrastructure of bare metals, to enhance the security to get zero trust of the host.</p>


### PR DESCRIPTION
Also update the gmt offset configuration to use Standard time.
The initial implementation used Daylight time, which is confusing
to people now that time zones have all adjusted.

Signed-off-by: Aaron Conole <aconole@redhat.com>