### PR TITLE
conf2024: Update the schedule.

### DIFF
--- a/support/ovscon2024/index.html
+++ b/support/ovscon2024/index.html
@@ -77,7 +77,7 @@ function update_times() {
 }
 </script>
 <label for="gmtoff">UTC offset:</label>
-<input type="text" id="gmtoff" name="gmtoff" value="0" size="8" maxlength="5" onchange="update_times();">
+<input type="text" id="gmtoff" name="gmtoff" value="1" size="8" maxlength="5" onchange="update_times();">
 
 <h2>Day 1</h2>
 <table border=1>
@@ -91,8 +91,9 @@ function update_times() {
     <tr><td><a href="#t4">Integrating OVN into the Network Fabric</a></td><td class="time" day="20" start="610" end="645">Nov</td></tr>
     <tr><td><a href="#t5">First projects as a new OVN developer</a></td><td class="time" day="20" start="645" end="655">Nov</td></tr>
     <tr><td>Lunch</td><td class="time" day="20" start="660" end="715">Nov</td></tr>
-    <tr><td><a href="#t6">Open vSwitch (OVS) performance case study - From software to hardware offloading, from kernel to userspace</a></td><td class="time" day="20" start="720" end="760">Nov</td></tr>
-    <tr><td><a href="#t7">Pluggable DPIF - Unlocking accelerated OVS full potential</a></td><td class="time" day="20" start="765" end="800">Nov</td></tr>
+    <tr><td><a href="#t18">OVS DOCA - The Evolution of hardware acceleration</a></td><td class="time" day="20" start="720" end="745">Nov</td></tr>
+    <tr><td><a href="#t7">Pluggable DPIF - Unlocking accelerated OVS full potential</a></td><td class="time" day="20" start="750" end="785">Nov</td></tr>
+    <tr><td><a href="#t21">Can 'ofproto/trace' go live</a></td><td class="time" day="20" start="790" end="800">Nov</td></tr>
     <tr><td>Break</td><td class="time" day="20" start="805" end="830">Nov</td></tr>
     <tr><td><a href="#t8">OpenShift Networking Transformed: Fully Embracing DPDK Datapaths in OVN-K8s!</a></td><td class="time" day="20" start="835" end="860">Nov</td></tr>
     <tr><td><a href="#t9">Automating Root Cause Analysis in OVS/OVN-Based Deployments Using AI/ML</a></td><td class="time" day="20" start="865" end="890">Nov</td></tr>
@@ -101,6 +102,7 @@ function update_times() {
     <tr><td><a href="#t11">Harnessing Marvell Accelerators with OVS Hardware Offload for Accelerated Network Performance</a></td><td class="time" day="20" start="920" end="945">Nov</td></tr>
     <tr><td><a href="#t12">Inclusive Naming</a></td><td class="time" day="20" start="950" end="960">Nov</td></tr>
     <tr><td>Closing Remarks: Day 1</td><td class="time" day="20" start="960" end="965">Nov</td></tr>
+    <tr><td>Dinner</td><td class="time" day="20" start="1005" end="1080">Nov</td></tr>
 </table>
 
 <h2>Day 2</h2>
@@ -112,15 +114,14 @@ function update_times() {
     <tr><td><a href="#t16">VM Migration Enhancements</a></td><td class="time" day="21" start="570" end="580">Nov</td></tr>
     <tr><td>Break</td><td class="time" day="21" start="585" end="605">Nov</td></tr>
     <tr><td><a href="#t17">Introducing exact-match hardware offload for OVS</a></td><td class="time" day="21" start="610" end="635">Nov</td></tr>
-    <tr><td><a href="#t18">OVS DOCA - The Evolution of hardware acceleration</a></td><td class="time" day="21" start="640" end="665">Nov</td></tr>
+    <tr><td><a href="#t22">Composable Services in OVN</a></td><td class="time" day="21" start="640" end="665">Nov</td></tr>
     <tr><td>Lunch</td><td class="time" day="21" start="670" end="725">Nov</td></tr>
-    <tr><td><a href="#t19">(P)sampling kubernetes network policies</a></td><td class="time" day="21" start="730" end="755">Nov</td></tr>
-    <tr><td><a href="#t20">Tracing packets in OVS: an update on Retis</a></td><td class="time" day="21" start="760" end="785">Nov</td></tr>
-    <tr><td><a href="#t21">Can 'ofproto/trace' go live</a></td><td class="time" day="21" start="790" end="800">Nov</td></tr>
+    <tr><td><a href="#t6">Open vSwitch (OVS) performance case study - From software to hardware offloading, from kernel to userspace</a></td><td class="time" day="20" start="730" end="770">Nov</td></tr>
+    <tr><td><a href="#t19">(P)sampling kubernetes network policies</a></td><td class="time" day="21" start="775" end="800">Nov</td></tr>
     <tr><td>Break</td><td class="time" day="21" start="805" end="825">Nov</td></tr>
-    <tr><td><a href="#t22">Composable Services in OVN</a></td><td class="time" day="21" start="830" end="855">Nov</td></tr>
-    <tr><td><a href="#t23">P4OVN: Offloading OVN to Intel IPU for Intel Developer Cloud</a></td><td class="time" day="21" start="860" end="885">Nov</td></tr>
-    <tr><td>Closing Remarks</td><td class="time" day="21" start="900" end="905">Nov</td></tr>
+    <tr><td><a href="#t20">Tracing packets in OVS: an update on Retis</a></td><td class="time" day="21" start="825" end="850">Nov</td></tr>
+    <tr><td><a href="#t23">P4OVN: Offloading OVN to Intel IPU for Intel Developer Cloud</a></td><td class="time" day="21" start="855" end="880">Nov</td></tr>
+    <tr><td>Closing Remarks</td><td class="time" day="21" start="885" end="890">Nov</td></tr>
 </table>
 
 <h2>Talks</h2>


### PR DESCRIPTION
1. Make the default to UTC+1 timezone
2. Add the dinner to the schedule.
3. Re-arrange the OVS DOCA talks (Alin request)
