### PR TITLE
ovsconf 2025: Deadline extension.

### DIFF
--- a/support/ovscon2025/index.html
+++ b/support/ovscon2025/index.html
@@ -39,7 +39,7 @@ title: Open vSwitch and OVN 2025 Fall Conference
 <p>
     Please submit proposals
     to <a href="mailto:ovscon@openvswitch.org">ovscon@openvswitch.org</a>
-    by September 8.  Proposals should include:
+    by September 22.  Proposals should include:
 </p>
 
 <ul>
@@ -52,7 +52,7 @@ title: Open vSwitch and OVN 2025 Fall Conference
 </ul>
 
 <p>
-    Speakers will be notified of acceptance by October 1st, 2025.
+    Speakers will be notified of acceptance by October 8th, 2025.
 </p>
 
 <p>Speakers should plan to attend the event in person.  Travel and


### PR DESCRIPTION
After discussion it was determined that the deadline for submissions be pushed by 2 weeks, and for notification by 1 week.