### PR TITLE
schedule: Introduce a last-minute talk.

### DIFF
--- a/support/ovscon2025/index.html
+++ b/support/ovscon2025/index.html
@@ -83,7 +83,7 @@ function update_times() {
     <tr><td>Registration / Check in</td><td class="time" day="19" start="420" end="480">Nov</td></tr>
     <tr><td>Opening Remarks</td><td class="time" day="19" start="480" end="505">Nov</td></tr>
     <tr><td><a href="#t1">Observing Open vSwitch with native prometheus metrics</a></td><td class="time" day="19" start="510" end="535">Nov</td></tr>
-    <tr><td><a href="#t2">Enhancing hardware offload insights in OVS</a></td><td class="time" day="19" start="540" end="550">Nov</td></tr>
+    <tr><td><a href="#t2">When CI Shouts Back: LLMs in the OVS CI Pipeline</a></td><td class="time" day="19" start="540" end="550">Nov</td></tr>
     <tr><td><a href="#t3">AI-Powered Performance Insights: Integrating OVS/OVN automatic performance regression analysis with LLMs</a></td><td class="time" day="19" start="555" end="590">Nov</td></tr>
     <tr><td>Break</td><td class="time" day="19" start="595" end="610">Nov</td></tr>
     <tr><td><a href="#t4">OpenFlow Classifier: Arcane knowledge and common pitfalls</a></td><td class="time" day="19" start="615" end="640">Nov</td></tr>
@@ -158,26 +158,14 @@ ofproto layer and specialized metrics made possible in the userspace
 datapath.
 </pre>
 
-<h3 id="t2">Enhancing hardware offload insights in OVS <a href="#day1">|TOP|</a></h3>
-<h3>Speaker(s): Nupur Uttarwar, NVIDIA</h3>
+<h3 id="t2">When CI Shouts Back: LLMs in the OVS CI Pipeline <a href="#day1">|TOP|</a></h3>
+<h3>Speaker(s): Eelco Chaudron, Red Hat; Aaron Conole, Red Hat</h3>
 <pre>
-In Open vSwitch, troubleshooting rule offloading often requires digging
-through logs and cross-referencing system components, especially when
-offload fails or is unsupported. This short talk introduces enhancements
-to the “dpctl dump-flows” command that provide explicit per-rule failure
-if any directly in the flow dump output. With these improvements, users
-gain streamlined troubleshooting and clearer insight into the offloading
-pipeline, accelerating root-cause analysis and system fine-tuning.
-
-    This talk will cover the following:
-
-    *   Motivation for improving flow offload visibility and transparency
-    *   Overview of new enhancements: error detection, propagation, and
-        exposure in the data path
-
-Finally, I will show the usage in practice where the offload fails and
-how users can benefit from immediate, actionable feedback on offload
-failures.
+A lightning talk exploring recent experiments in the upstream CI pipeline
+using CodeRabbit, Sourcery, and Claude SONNET models for assisting with
+code review.  We'll give an overview of our experiences with these tools,
+some interesting analysis results, and future steps for integrating an
+LLM into the CI development process.
 </pre>
 
 <h3 id="t3">AI-Powered Performance Insights: Integrating OVS/OVN automatic performance regression analysis with LLMs <a href="#day1">|TOP|</a></h3>


### PR DESCRIPTION
The talk being replaced was pulled at the last minute due to medical emergency.  This will be a quick lightning talk that covers recent efforts to integrate LLM analysis into the OVS CI pipeline, and where that work will go.